### PR TITLE
Pin FluentAssertions to v7

### DIFF
--- a/source/SeqFlatFileImport.Tests/SeqFlatFileImport.Tests.csproj
+++ b/source/SeqFlatFileImport.Tests/SeqFlatFileImport.Tests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Assent" Version="2.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />


### PR DESCRIPTION
[sc-101162]

FluentAssertions v8 changes to a non-open-source license; Commercial Use requires a paid subscription at $129 USD per developer per year.

This PR pins the version of FluentAssertions to 7.1.0.